### PR TITLE
Summary:Add idle_notifier_(un/)register functions

### DIFF
--- a/arch/x86/kernel/process.c
+++ b/arch/x86/kernel/process.c
@@ -68,6 +68,20 @@ EXPORT_PER_CPU_SYMBOL(cpu_tss);
 DEFINE_PER_CPU(bool, need_tr_refresh);
 EXPORT_PER_CPU_SYMBOL_GPL(need_tr_refresh);
 
+static ATOMIC_NOTIFIER_HEAD(idle_notifier);
+
+void idle_notifier_register(struct notifier_block *n)
+{
+	atomic_notifier_chain_register(&idle_notifier, n);
+}
+EXPORT_SYMBOL_GPL(idle_notifier_register);
+
+void idle_notifier_unregister(struct notifier_block *n)
+{
+	atomic_notifier_chain_unregister(&idle_notifier, n);
+}
+EXPORT_SYMBOL_GPL(idle_notifier_unregister);
+
 /*
  * this gets called so that we can store lazy state into memory and copy the
  * current task into the new thread.

--- a/include/linux/cpu.h
+++ b/include/linux/cpu.h
@@ -158,4 +158,10 @@ void cpuhp_report_idle_dead(void);
 static inline void cpuhp_report_idle_dead(void) { }
 #endif /* #ifdef CONFIG_HOTPLUG_CPU */
 
+#define IDLE_START 1
+#define IDLE_END 2
+
+void idle_notifier_register(struct notifier_block *n);
+void idle_notifier_unregister(struct notifier_block *n);
+
 #endif /* _LINUX_CPU_H_ */


### PR DESCRIPTION
       The idle_notifier_register and unregister functions are being
       used by the cpufreq core.

Jira: None

Test: Able to boot with these changes and see acpi_cpufreq driver being enabled.

Signed-off-by: Sameer Lattannavar <sameer.lattannavar@intel.com>