### PR TITLE
Bluetooth Driver  : Reducing Command Credit from Controller to 1 always

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -1922,6 +1922,18 @@ static int btusb_recv_event_intel(struct hci_dev *hdev, struct sk_buff *skb)
 			}
 		}
 	}
+	else if (skb->len >= sizeof(struct hci_event_hdr)) {
+		struct hci_event_hdr *hdr;
+     
+		hdr = (struct hci_event_hdr *) skb->data;
+ 
+		if (hdr->evt == HCI_EV_CMD_COMPLETE) {
+			*(__u8 *)(skb->data + 2) = 1;
+		} else if (hdr->evt == HCI_EV_CMD_STATUS) {
+			*(__u8 *)(skb->data + 3) = 1;
+		}
+    }   
+	
 
 	return hci_recv_frame(hdev, skb);
 }


### PR DESCRIPTION
Intel BT Controller can not handle 2 Commands from the host at the same time.Mostly they crashes and make BT unstable. Hence reducing the command credit in all cases equal to 1.

http://01.org/jira/browse/AIA-134

Pairing/Connection/File Transfer/A2DP found to be working .
Signed-off-by: avaish1 <atul.vaish@intel.com>