### PR TITLE
[REVERT ME] Fix for rules check failure seen due to Netd mismatch

### DIFF
--- a/include/net/fib_rules.h
+++ b/include/net/fib_rules.h
@@ -98,6 +98,8 @@ struct fib_rules_ops {
 	[FRA_SUPPRESS_PREFIXLEN] = { .type = NLA_U32 }, \
 	[FRA_SUPPRESS_IFGROUP] = { .type = NLA_U32 }, \
 	[FRA_GOTO]	= { .type = NLA_U32 }, \
+	[FRA_UID_START] = { .type = NLA_U32 }, \
+	[FRA_UID_END] = { .type = NLA_U32 }, \
 	[FRA_L3MDEV]	= { .type = NLA_U8 }, \
 	[FRA_UID_RANGE]	= { .len = sizeof(struct fib_rule_uid_range) }
 

--- a/include/uapi/linux/fib_rules.h
+++ b/include/uapi/linux/fib_rules.h
@@ -54,6 +54,8 @@ enum {
 	FRA_TABLE,	/* Extended table id */
 	FRA_FWMASK,	/* mask for netfilter mark */
 	FRA_OIFNAME,
+	FRA_UID_START,
+	FRA_UID_END,
 	FRA_PAD,
 	FRA_L3MDEV,	/* iif or oif is l3mdev goto its table */
 	FRA_UID_RANGE,	/* UID range */


### PR DESCRIPTION
If netd doesnt have support for providing UID range,
updating of the rules fails due to invalid UID.

This patch fixes the issue by adding support for
handling the UI provided using UID_START and UI_END
fields.

JIRA: https://01.org/jira/browse/AIA-236
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>