### PR TITLE
cold boot time optimization

### DIFF
--- a/drivers/gpu/drm/i915/intel_ddi.c
+++ b/drivers/gpu/drm/i915/intel_ddi.c
@@ -2259,6 +2259,8 @@ void intel_ddi_init(struct drm_i915_private *dev_priv, enum port port)
 	intel_encoder->crtc_mask = (1 << 0) | (1 << 1) | (1 << 2);
 	intel_encoder->cloneable = 0;
 
+	init_dp = init_lspcon = false;
+
 	if (init_dp) {
 		if (!intel_ddi_init_dp_connector(intel_dig_port))
 			goto err;


### PR DESCRIPTION
Port from Android M
i915 fast init can optimize cold boot time.

JIRA: https://jira01.devtools.intel.com/browse/OAM-45841
Tests: Joule's EB test shows kernel boot time was reduced

Signed-off-by: boyangX <box.a.yang@intel.com>