### PR TITLE
[REVERTME] usb: dwc3: disable autosuspend

### DIFF
--- a/drivers/usb/dwc3/core.c
+++ b/drivers/usb/dwc3/core.c
@@ -47,7 +47,7 @@
 
 #include "debug.h"
 
-#define DWC3_DEFAULT_AUTOSUSPEND_DELAY	5000 /* ms */
+#define DWC3_DEFAULT_AUTOSUSPEND_DELAY	(-1)  /* prevent RTPM for usb */
 
 /**
  * dwc3_get_dr_mode - Validates and sets dr_mode


### PR DESCRIPTION
Host to device mode switch does not always work since
gadget driver may get suspended after the connect event.
Since, power management is anyways not up yet, disabling
autosuspend for USB dwc3 driver.

JIRA: OAM-47098
Test: Device to host mode & vice-versa works on Joule.

Signed-off-by: Abhilash K V <abhilash.k.v@intel.com>