### PR TITLE
Revert "REVERTME: Fix issue with UID range."

### DIFF
--- a/include/net/fib_rules.h
+++ b/include/net/fib_rules.h
@@ -107,8 +107,6 @@ struct fib_rule_notifier_info {
 	[FRA_SUPPRESS_PREFIXLEN] = { .type = NLA_U32 }, \
 	[FRA_SUPPRESS_IFGROUP] = { .type = NLA_U32 }, \
 	[FRA_GOTO]	= { .type = NLA_U32 }, \
-	[FRA_UID_START] = { .type = NLA_U32 }, \
-	[FRA_UID_END] = { .type = NLA_U32 }, \
 	[FRA_L3MDEV]	= { .type = NLA_U8 }, \
 	[FRA_UID_RANGE]	= { .len = sizeof(struct fib_rule_uid_range) }
 

--- a/include/uapi/linux/fib_rules.h
+++ b/include/uapi/linux/fib_rules.h
@@ -55,8 +55,6 @@ enum {
 	FRA_TABLE,	/* Extended table id */
 	FRA_FWMASK,	/* mask for netfilter mark */
 	FRA_OIFNAME,
-	FRA_UID_START,
-	FRA_UID_END,
 	FRA_PAD,
 	FRA_L3MDEV,	/* iif or oif is l3mdev goto its table */
 	FRA_UID_RANGE,	/* UID range */

--- a/net/core/fib_rules.c
+++ b/net/core/fib_rules.c
@@ -548,24 +548,6 @@ int fib_nl_newrule(struct sk_buff *skb, struct nlmsghdr *nlh,
 	if (rule->l3mdev && rule->table)
 		goto errout_free;
 
-	if (tb[FRA_UID_START] && tb[FRA_UID_END]) {
-		if (current_user_ns() != net->user_ns) {
-			err = -EPERM;
-			goto errout_free;
-		}
-
-		rule->uid_range.start = make_kuid(current_user_ns(),
-						nla_get_u32(tb[FRA_UID_START]));
-		rule->uid_range.end = make_kuid(current_user_ns(),
-						nla_get_u32(tb[FRA_UID_END]));
-
-		if (!uid_range_set(&rule->uid_range) ||
-				!uid_lte(rule->uid_range.start, rule->uid_range.end))
-			goto errout_free;
-	} else {
-		rule->uid_range = fib_kuid_range_unset;
-	}
-
 	if (tb[FRA_UID_RANGE]) {
 		if (current_user_ns() != net->user_ns) {
 			err = -EPERM;
@@ -668,18 +650,6 @@ int fib_nl_delrule(struct sk_buff *skb, struct nlmsghdr *nlh,
 	err = validate_rulemsg(frh, tb, ops);
 	if (err < 0)
 		goto errout;
-
-	if (tb[FRA_UID_START] && tb[FRA_UID_END]) {
-		range.start = make_kuid(current_user_ns(),
-					nla_get_u32(tb[FRA_UID_START]));
-		range.end = make_kuid(current_user_ns(),
-					nla_get_u32(tb[FRA_UID_END]));
-
-		if (!uid_range_set(&range))
-			goto errout;
-	} else {
-		range = fib_kuid_range_unset;
-	}
 
 	if (tb[FRA_UID_RANGE]) {
 		range = nla_get_kuid_range(tb);


### PR DESCRIPTION
The patch is just for android N which had old Netd but the kernel had UID Range support.
Android O had fixed the issue, so no need this patch again.

This reverts commit 95e6a2e8e5d87528656c8d053f27c44ceb92e9d3.

JIRA: None.
Test: AlwaysOnVPN releted CTS cases pass.